### PR TITLE
swap styles for colored buttons and selected variants

### DIFF
--- a/.changeset/eleven-sloths-count.md
+++ b/.changeset/eleven-sloths-count.md
@@ -1,0 +1,5 @@
+---
+'@ryanatkn/moss': minor
+---
+
+swap styles for colored buttons and selected variants

--- a/src/lib/style.css
+++ b/src/lib/style.css
@@ -484,16 +484,6 @@ so for consistent visuals we opt to include no active state */
 /*  TODO :has selector? `button:has(input[type='checkbox']:checked)`
 see https://caniuse.com/css-has
  */
-/* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
-currently `:disabled` overrides this */
-:where(button.selected) {
-	--text_color: var(--text_active);
-	--border_color: hsl(var(--color_a_5));
-}
-:where(button.selected:not(.deselectable)) {
-	cursor: default;
-	box-shadow: none;
-}
 :where(input:checked) {
 	--text_color: var(--text_active);
 	--border_color: hsl(var(--color_a_5));
@@ -520,23 +510,7 @@ currently `:disabled` overrides this */
 }
 
 /* TODO these need design work for visuals/consistency/customizability  */
-:where(
-		button:where(
-				.color_a,
-				.color_b,
-				.color_c,
-				.color_d,
-				.color_e,
-				.color_f,
-				.color_g,
-				.color_h,
-				.color_i
-			)
-	) {
-	--text_color: var(
-		--bg_8
-	); /* TODO rethink this, maybe gradients instead? or at least use a text_color */
-}
+/* TODO rethink this, maybe gradients instead? or at least use a text_color */
 :where(
 		button:where(
 				.color_a,
@@ -552,82 +526,93 @@ currently `:disabled` overrides this */
 	) {
 	--text_color: var(--bg_10);
 }
-/* TODO maybe move these to `style_components` or a different CSS file? */
+/*
+TODO maybe move these to `style_components.css` or a different CSS file?
+including colored button styles, selected button styles, ...
+*/
 :where(button.color_a) {
 	/* TODO change to setting a variable */
-	--fill: var(--fill_a);
+	--text_color: hsl(var(--color_a_5));
 	--border_color: var(--border_color_a);
 }
 :where(button.color_b) {
-	--fill: var(--fill_b);
+	--text_color: hsl(var(--color_b_5));
 	--border_color: var(--border_color_b);
 	--outline_color: var(--border_color_b);
 }
 :where(button.color_c) {
-	--fill: var(--fill_c);
+	--text_color: hsl(var(--color_c_5));
 	--border_color: var(--border_color_c);
 	--outline_color: var(--border_color_c);
 }
 :where(button.color_d) {
-	--fill: var(--fill_d);
+	--text_color: hsl(var(--color_d_5));
 	--border_color: var(--border_color_d);
 	--outline_color: var(--border_color_d);
 }
 :where(button.color_e) {
-	--fill: var(--fill_e);
+	--text_color: hsl(var(--color_e_5));
 	--border_color: var(--border_color_e);
 	--outline_color: var(--border_color_e);
 }
 :where(button.color_f) {
-	--fill: var(--fill_f);
+	--text_color: hsl(var(--color_f_5));
 	--border_color: var(--border_color_f);
 	--outline_color: var(--border_color_f);
 }
 :where(button.color_g) {
-	--fill: var(--fill_g);
+	--text_color: hsl(var(--color_g_5));
 	--border_color: var(--border_color_g);
 	--outline_color: var(--border_color_g);
 }
 :where(button.color_h) {
-	--fill: var(--fill_h);
+	--text_color: hsl(var(--color_h_5));
 	--border_color: var(--border_color_h);
 	--outline_color: var(--border_color_h);
 }
 :where(button.color_i) {
-	--fill: var(--fill_i);
+	--text_color: hsl(var(--color_i_5));
 	--border_color: var(--border_color_i);
 	--outline_color: var(--border_color_i);
 }
-/* TODO set text_color */
-:where(button.selected.color_a) {
-	--text_color: hsl(var(--color_a_5));
-}
-:where(button.selected.color_b) {
-	--text_color: hsl(var(--color_b_5));
-}
-:where(button.selected.color_c) {
-	--text_color: hsl(var(--color_c_5));
-}
-:where(button.selected.color_d) {
-	--text_color: hsl(var(--color_d_5));
-}
-:where(button.selected.color_e) {
-	--text_color: hsl(var(--color_e_5));
-}
-:where(button.selected.color_f) {
-	--text_color: hsl(var(--color_f_5));
-}
-:where(button.selected.color_g) {
-	--text_color: hsl(var(--color_g_5));
-}
-:where(button.selected.color_h) {
-	--text_color: hsl(var(--color_h_5));
-}
-:where(button.selected.color_i) {
-	--text_color: hsl(var(--color_i_5));
-}
+/* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
+currently `:disabled` overrides this */
 :where(button.selected) {
+	--text_color: var(--bg_8);
+	--border_color: hsl(var(--color_a_5));
 	--fill: var(--button_fill_selected);
+}
+:where(button.selected:not(.deselectable)) {
+	cursor: default;
+	box-shadow: none;
+}
+/* TODO set text_color */
+:where(button.color_a.selected) {
+	--fill: var(--fill_a);
+}
+:where(button.color_b.selected) {
+	--fill: var(--fill_b);
+}
+:where(button.color_c.selected) {
+	--fill: var(--fill_c);
+}
+:where(button.color_d.selected) {
+	--fill: var(--fill_d);
+}
+:where(button.color_e.selected) {
+	--fill: var(--fill_e);
+}
+:where(button.color_f.selected) {
+	--fill: var(--fill_f);
+}
+:where(button.color_g.selected) {
+	--fill: var(--fill_g);
+}
+:where(button.color_h.selected) {
+	--fill: var(--fill_h);
+}
+:where(button.color_i.selected) {
+	--fill: var(--fill_i);
 }
 
 /* TODO could improve this with the coming `:has` selector

--- a/src/lib/style.css
+++ b/src/lib/style.css
@@ -511,6 +511,14 @@ see https://caniuse.com/css-has
 
 /* TODO these need design work for visuals/consistency/customizability  */
 /* TODO rethink this, maybe gradients instead? or at least use a text_color */
+/* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
+currently `:disabled` overrides this */
+/* TODO hover variants with brighter borders? maybe use a colorless border for that? */
+:where(button.selected) {
+	--text_color: var(--bg_8);
+	--border_color: var(--border_color_2);
+	--fill: var(--button_fill_selected);
+}
 :where(
 		button:where(
 				.color_a,
@@ -531,7 +539,6 @@ TODO maybe move these to `style_components.css` or a different CSS file?
 including colored button styles, selected button styles, ...
 */
 :where(button.color_a) {
-	/* TODO change to setting a variable */
 	--text_color: hsl(var(--color_a_5));
 	--border_color: var(--border_color_a);
 }
@@ -575,18 +582,17 @@ including colored button styles, selected button styles, ...
 	--border_color: var(--border_color_i);
 	--outline_color: var(--border_color_i);
 }
-/* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
-currently `:disabled` overrides this */
+/*
+This selector follows the colored buttons to override them.
+Other `button.selected` styles are above.
+*/
 :where(button.selected) {
 	--text_color: var(--bg_8);
-	--border_color: hsl(var(--color_a_5));
-	--fill: var(--button_fill_selected);
 }
 :where(button.selected:not(.deselectable)) {
 	cursor: default;
 	box-shadow: none;
 }
-/* TODO set text_color */
 :where(button.color_a.selected) {
 	--fill: var(--fill_a);
 }

--- a/src/lib/style.css
+++ b/src/lib/style.css
@@ -494,9 +494,8 @@ see https://caniuse.com/css-has
 /* TODO maybe shouldn't mix button in with these */
 :where(:where(input, textarea, select, button):disabled) {
 	--text_color: var(--text_disabled);
-	--fill: var(
-		--button_fill_disabled
-	); /* TODO using `button_` here looks wrong, conflating button with others */
+	/* TODO using `button_` here looks wrong, conflating button with others */
+	--fill: var(--button_fill_disabled);
 	--border_color: var(--border_disabled);
 	--border_style: solid dashed;
 	cursor: default;
@@ -514,8 +513,11 @@ see https://caniuse.com/css-has
 /* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
 currently `:disabled` overrides this */
 /* TODO hover variants with brighter borders? maybe use a colorless border for that? */
+/*
+This selector appears twice, once before and once after the color button styles,
+to take advantage of the cascade to minimize overrides.
+*/
 :where(button.selected) {
-	--text_color: var(--bg_8);
 	--border_color: var(--border_color_2);
 	--fill: var(--button_fill_selected);
 }
@@ -540,47 +542,65 @@ including colored button styles, selected button styles, ...
 */
 :where(button.color_a) {
 	--text_color: hsl(var(--color_a_5));
+	--fill: hsl(var(--color_a_5) / 0.1);
 	--border_color: var(--border_color_a);
 }
 :where(button.color_b) {
 	--text_color: hsl(var(--color_b_5));
+	--fill: hsl(var(--color_b_5) / 0.1);
 	--border_color: var(--border_color_b);
 	--outline_color: var(--border_color_b);
 }
 :where(button.color_c) {
 	--text_color: hsl(var(--color_c_5));
+	--fill: hsl(var(--color_c_5) / 0.1);
 	--border_color: var(--border_color_c);
 	--outline_color: var(--border_color_c);
 }
 :where(button.color_d) {
 	--text_color: hsl(var(--color_d_5));
+	--fill: hsl(var(--color_d_5) / 0.1);
 	--border_color: var(--border_color_d);
 	--outline_color: var(--border_color_d);
 }
 :where(button.color_e) {
 	--text_color: hsl(var(--color_e_5));
+	--fill: hsl(var(--color_e_5) / 0.1);
 	--border_color: var(--border_color_e);
 	--outline_color: var(--border_color_e);
 }
 :where(button.color_f) {
 	--text_color: hsl(var(--color_f_5));
+	--fill: hsl(var(--color_f_5) / 0.1);
 	--border_color: var(--border_color_f);
 	--outline_color: var(--border_color_f);
 }
 :where(button.color_g) {
 	--text_color: hsl(var(--color_g_5));
+	--fill: hsl(var(--color_g_5) / 0.1);
 	--border_color: var(--border_color_g);
 	--outline_color: var(--border_color_g);
 }
 :where(button.color_h) {
 	--text_color: hsl(var(--color_h_5));
+	--fill: hsl(var(--color_h_5) / 0.1);
 	--border_color: var(--border_color_h);
 	--outline_color: var(--border_color_h);
 }
 :where(button.color_i) {
 	--text_color: hsl(var(--color_i_5));
+	--fill: hsl(var(--color_i_5) / 0.1);
 	--border_color: var(--border_color_i);
 	--outline_color: var(--border_color_i);
+}
+/*
+This selector appears twice, once before and once after the color button styles.
+Also if we add colored inputs, they would be added to this selector list.
+*/
+:where(button:disabled:not(.selected)) {
+	--fill: var(--button_fill_disabled);
+	/* TODO maybe change this border color for color buttons? or remove it completely?  */
+	/* --border_color: var(--border_disabled); */
 }
 /*
 This selector follows the colored buttons to override them.

--- a/src/lib/style_reset.css
+++ b/src/lib/style_reset.css
@@ -490,9 +490,8 @@ see https://caniuse.com/css-has
 /* TODO maybe shouldn't mix button in with these */
 :where(:where(input, textarea, select, button):disabled) {
 	--text_color: var(--text_disabled);
-	--fill: var(
-		--button_fill_disabled
-	); /* TODO using `button_` here looks wrong, conflating button with others */
+	/* TODO using `button_` here looks wrong, conflating button with others */
+	--fill: var(--button_fill_disabled);
 	--border_color: var(--border_disabled);
 	--border_style: solid dashed;
 	cursor: default;
@@ -510,8 +509,11 @@ see https://caniuse.com/css-has
 /* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
 currently `:disabled` overrides this */
 /* TODO hover variants with brighter borders? maybe use a colorless border for that? */
+/*
+This selector appears twice, once before and once after the color button styles,
+to take advantage of the cascade to minimize overrides.
+*/
 :where(button.selected) {
-	--text_color: var(--bg_8);
 	--border_color: var(--border_color_2);
 	--fill: var(--button_fill_selected);
 }
@@ -536,47 +538,65 @@ including colored button styles, selected button styles, ...
 */
 :where(button.color_a) {
 	--text_color: hsl(var(--color_a_5));
+	--fill: hsl(var(--color_a_5) / 0.1);
 	--border_color: var(--border_color_a);
 }
 :where(button.color_b) {
 	--text_color: hsl(var(--color_b_5));
+	--fill: hsl(var(--color_b_5) / 0.1);
 	--border_color: var(--border_color_b);
 	--outline_color: var(--border_color_b);
 }
 :where(button.color_c) {
 	--text_color: hsl(var(--color_c_5));
+	--fill: hsl(var(--color_c_5) / 0.1);
 	--border_color: var(--border_color_c);
 	--outline_color: var(--border_color_c);
 }
 :where(button.color_d) {
 	--text_color: hsl(var(--color_d_5));
+	--fill: hsl(var(--color_d_5) / 0.1);
 	--border_color: var(--border_color_d);
 	--outline_color: var(--border_color_d);
 }
 :where(button.color_e) {
 	--text_color: hsl(var(--color_e_5));
+	--fill: hsl(var(--color_e_5) / 0.1);
 	--border_color: var(--border_color_e);
 	--outline_color: var(--border_color_e);
 }
 :where(button.color_f) {
 	--text_color: hsl(var(--color_f_5));
+	--fill: hsl(var(--color_f_5) / 0.1);
 	--border_color: var(--border_color_f);
 	--outline_color: var(--border_color_f);
 }
 :where(button.color_g) {
 	--text_color: hsl(var(--color_g_5));
+	--fill: hsl(var(--color_g_5) / 0.1);
 	--border_color: var(--border_color_g);
 	--outline_color: var(--border_color_g);
 }
 :where(button.color_h) {
 	--text_color: hsl(var(--color_h_5));
+	--fill: hsl(var(--color_h_5) / 0.1);
 	--border_color: var(--border_color_h);
 	--outline_color: var(--border_color_h);
 }
 :where(button.color_i) {
 	--text_color: hsl(var(--color_i_5));
+	--fill: hsl(var(--color_i_5) / 0.1);
 	--border_color: var(--border_color_i);
 	--outline_color: var(--border_color_i);
+}
+/*
+This selector appears twice, once before and once after the color button styles.
+Also if we add colored inputs, they would be added to this selector list.
+*/
+:where(button:disabled:not(.selected)) {
+	--fill: var(--button_fill_disabled);
+	/* TODO maybe change this border color for color buttons? or remove it completely?  */
+	/* --border_color: var(--border_disabled); */
 }
 /*
 This selector follows the colored buttons to override them.

--- a/src/lib/style_reset.css
+++ b/src/lib/style_reset.css
@@ -574,7 +574,7 @@ including colored button styles, selected button styles, ...
 currently `:disabled` overrides this */
 :where(button.selected) {
 	--text_color: var(--bg_8);
-	--border_color: hsl(var(--color_a_5));
+	--border_color: hsl(var(--border_color_5));
 	--fill: var(--button_fill_selected);
 }
 :where(button.selected:not(.deselectable)) {

--- a/src/lib/style_reset.css
+++ b/src/lib/style_reset.css
@@ -507,6 +507,14 @@ see https://caniuse.com/css-has
 
 /* TODO these need design work for visuals/consistency/customizability  */
 /* TODO rethink this, maybe gradients instead? or at least use a text_color */
+/* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
+currently `:disabled` overrides this */
+/* TODO hover variants with brighter borders? maybe use a colorless border for that? */
+:where(button.selected) {
+	--text_color: var(--bg_8);
+	--border_color: var(--border_color_2);
+	--fill: var(--button_fill_selected);
+}
 :where(
 		button:where(
 				.color_a,
@@ -570,12 +578,12 @@ including colored button styles, selected button styles, ...
 	--border_color: var(--border_color_i);
 	--outline_color: var(--border_color_i);
 }
-/* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
-currently `:disabled` overrides this */
+/*
+This selector follows the colored buttons to override them.
+Other `button.selected` styles are above.
+*/
 :where(button.selected) {
 	--text_color: var(--bg_8);
-	--border_color: hsl(var(--border_color_5));
-	--fill: var(--button_fill_selected);
 }
 :where(button.selected:not(.deselectable)) {
 	cursor: default;

--- a/src/lib/style_reset.css
+++ b/src/lib/style_reset.css
@@ -480,16 +480,6 @@ so for consistent visuals we opt to include no active state */
 /*  TODO :has selector? `button:has(input[type='checkbox']:checked)`
 see https://caniuse.com/css-has
  */
-/* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
-currently `:disabled` overrides this */
-:where(button.selected) {
-	--text_color: var(--text_active);
-	--border_color: hsl(var(--color_a_5));
-}
-:where(button.selected:not(.deselectable)) {
-	cursor: default;
-	box-shadow: none;
-}
 :where(input:checked) {
 	--text_color: var(--text_active);
 	--border_color: hsl(var(--color_a_5));
@@ -516,23 +506,7 @@ currently `:disabled` overrides this */
 }
 
 /* TODO these need design work for visuals/consistency/customizability  */
-:where(
-		button:where(
-				.color_a,
-				.color_b,
-				.color_c,
-				.color_d,
-				.color_e,
-				.color_f,
-				.color_g,
-				.color_h,
-				.color_i
-			)
-	) {
-	--text_color: var(
-		--bg_8
-	); /* TODO rethink this, maybe gradients instead? or at least use a text_color */
-}
+/* TODO rethink this, maybe gradients instead? or at least use a text_color */
 :where(
 		button:where(
 				.color_a,
@@ -548,82 +522,91 @@ currently `:disabled` overrides this */
 	) {
 	--text_color: var(--bg_10);
 }
-/* TODO maybe move these to `style_components` or a different CSS file? */
+/*
+TODO maybe move these to `style_components.css` or a different CSS file?
+including colored button styles, selected button styles, ...
+*/
 :where(button.color_a) {
-	/* TODO change to setting a variable */
-	--fill: var(--fill_a);
+	--text_color: hsl(var(--color_a_5));
 	--border_color: var(--border_color_a);
 }
 :where(button.color_b) {
-	--fill: var(--fill_b);
+	--text_color: hsl(var(--color_b_5));
 	--border_color: var(--border_color_b);
 	--outline_color: var(--border_color_b);
 }
 :where(button.color_c) {
-	--fill: var(--fill_c);
+	--text_color: hsl(var(--color_c_5));
 	--border_color: var(--border_color_c);
 	--outline_color: var(--border_color_c);
 }
 :where(button.color_d) {
-	--fill: var(--fill_d);
+	--text_color: hsl(var(--color_d_5));
 	--border_color: var(--border_color_d);
 	--outline_color: var(--border_color_d);
 }
 :where(button.color_e) {
-	--fill: var(--fill_e);
+	--text_color: hsl(var(--color_e_5));
 	--border_color: var(--border_color_e);
 	--outline_color: var(--border_color_e);
 }
 :where(button.color_f) {
-	--fill: var(--fill_f);
+	--text_color: hsl(var(--color_f_5));
 	--border_color: var(--border_color_f);
 	--outline_color: var(--border_color_f);
 }
 :where(button.color_g) {
-	--fill: var(--fill_g);
+	--text_color: hsl(var(--color_g_5));
 	--border_color: var(--border_color_g);
 	--outline_color: var(--border_color_g);
 }
 :where(button.color_h) {
-	--fill: var(--fill_h);
+	--text_color: hsl(var(--color_h_5));
 	--border_color: var(--border_color_h);
 	--outline_color: var(--border_color_h);
 }
 :where(button.color_i) {
-	--fill: var(--fill_i);
+	--text_color: hsl(var(--color_i_5));
 	--border_color: var(--border_color_i);
 	--outline_color: var(--border_color_i);
 }
-/* TODO set text_color */
-:where(button.selected.color_a) {
-	--text_color: hsl(var(--color_a_5));
-}
-:where(button.selected.color_b) {
-	--text_color: hsl(var(--color_b_5));
-}
-:where(button.selected.color_c) {
-	--text_color: hsl(var(--color_c_5));
-}
-:where(button.selected.color_d) {
-	--text_color: hsl(var(--color_d_5));
-}
-:where(button.selected.color_e) {
-	--text_color: hsl(var(--color_e_5));
-}
-:where(button.selected.color_f) {
-	--text_color: hsl(var(--color_f_5));
-}
-:where(button.selected.color_g) {
-	--text_color: hsl(var(--color_g_5));
-}
-:where(button.selected.color_h) {
-	--text_color: hsl(var(--color_h_5));
-}
-:where(button.selected.color_i) {
-	--text_color: hsl(var(--color_i_5));
-}
+/* TODO maybe add a style for `button.selected:disabled`, probably reduced brightness,
+currently `:disabled` overrides this */
 :where(button.selected) {
+	--text_color: var(--bg_8);
+	--border_color: hsl(var(--color_a_5));
 	--fill: var(--button_fill_selected);
+}
+:where(button.selected:not(.deselectable)) {
+	cursor: default;
+	box-shadow: none;
+}
+:where(button.color_a.selected) {
+	--fill: var(--fill_a);
+}
+:where(button.color_b.selected) {
+	--fill: var(--fill_b);
+}
+:where(button.color_c.selected) {
+	--fill: var(--fill_c);
+}
+:where(button.color_d.selected) {
+	--fill: var(--fill_d);
+}
+:where(button.color_e.selected) {
+	--fill: var(--fill_e);
+}
+:where(button.color_f.selected) {
+	--fill: var(--fill_f);
+}
+:where(button.color_g.selected) {
+	--fill: var(--fill_g);
+}
+:where(button.color_h.selected) {
+	--fill: var(--fill_h);
+}
+:where(button.color_i.selected) {
+	--fill: var(--fill_i);
 }
 
 /* TODO could improve this with the coming `:has` selector

--- a/src/lib/theme.css
+++ b/src/lib/theme.css
@@ -242,8 +242,8 @@
 	--radius_xs3: 0.3rem;
 	--button_fill: var(--fg_1);
 	--button_fill_hover: var(--fg_2);
-	--button_fill_active: var(--bg_3);
-	--button_fill_selected: var(--bg_3);
+	--button_fill_active: var(--fg_2);
+	--button_fill_selected: var(--fg_5);
 	--button_fill_disabled: transparent;
 	--input_fill: var(--bg_5);
 	--input_padding_y: 0;

--- a/src/lib/variables.ts
+++ b/src/lib/variables.ts
@@ -852,11 +852,11 @@ export const button_fill: Style_Variable = {name: 'button_fill', light: 'var(--f
 export const button_fill_hover: Style_Variable = {name: 'button_fill_hover', light: 'var(--fg_2)'}; // TODO keep these? what about `::before` and `::after` visuals with gradients/animations;
 export const button_fill_active: Style_Variable = {
 	name: 'button_fill_active',
-	light: 'var(--bg_3)',
+	light: 'var(--fg_2)',
 };
 export const button_fill_selected: Style_Variable = {
 	name: 'button_fill_selected',
-	light: 'var(--bg_3)',
+	light: 'var(--fg_5)',
 };
 export const button_fill_disabled: Style_Variable = {
 	name: 'button_fill_disabled',


### PR DESCRIPTION
Followup

- probably remove `hsl(` usage inside `variables.ts`
- brighter border colors and text for hovered colored buttons - use default border colors, so colorless? or add new border color variants? or remove border color variants and use the colors directly?
- active states for color disabled buttons
- gradient fills on buttons (maybe use softer shadows if not needed with gradients)
- inverting the shadows for dark mode on buttons looks wrong
- revisit disabled styles with colored buttons and uncolored
- `TODO maybe change this border color for color buttons? or remove it completely?`