### PR TITLE
fix CSS class generation sort order

### DIFF
--- a/.changeset/honest-oranges-appear.md
+++ b/.changeset/honest-oranges-appear.md
@@ -1,0 +1,5 @@
+---
+'@ryanatkn/moss': patch
+---
+
+fix CSS class generation sort order

--- a/src/lib/css_class_helpers.ts
+++ b/src/lib/css_class_helpers.ts
@@ -153,12 +153,26 @@ export interface Css_Class_Declaration_Group {
 	ruleset: string;
 }
 
+// TODO this API is going to change to allow non-static classes that get interpreted like a language at buildtime
 export const generate_classes_css = (
 	classes: Iterable<string>,
 	css_classes_by_name: Record<string, Css_Class_Declaration | undefined>,
 ): string => {
+	// TODO when the API is redesigned this kind of thing should be cached
+	// Create a map that has the index of each class name as the key
+	const indexes: Map<string, number> = new Map();
+	const keys = Object.keys(css_classes_by_name);
+	for (let i = 0; i < keys.length; i++) {
+		indexes.set(keys[i], i);
+	}
+
+	// If any classes are unknown, just put them at the end
+	const sorted_classes = (Array.isArray(classes) ? classes : Array.from(classes)).sort(
+		(a, b) => (indexes.get(a) ?? Number.MAX_VALUE) - (indexes.get(b) ?? Number.MAX_VALUE),
+	);
+
 	let css = '';
-	for (const c of classes) {
+	for (const c of sorted_classes) {
 		const v = css_classes_by_name[c];
 		if (!v) {
 			// diagnostic


### PR DESCRIPTION
fixes the fix of #46 - users may pass classes in any order, and we need to use the data structure's implicit order.